### PR TITLE
Logo margin

### DIFF
--- a/0index.html
+++ b/0index.html
@@ -75,6 +75,9 @@ body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: 
                 --chy-pr-5: #9255CE;
                 --chy-sd-1: #7237E9;
             }
+            #avlogo{
+                margin-left: 23px;
+            }
         
 </style>
 <link rel='stylesheet' id='elementor-icons-css' href='wp-content/plugins/elementor/assets/lib/eicons/css/elementor-icons.min.css' media='all' />
@@ -171,7 +174,7 @@ var woocommerce_params = {"ajax_url":"\/wp\/gilroy\/wp-admin\/admin-ajax.php","w
     <header class="gly-header-1-area has-header-2 tx-header " data-txStickyHeader>
     <div class="gly-header-1-container">
     <div class="gly-header-1-row">
-        <a class="gly-header-1-logo tx-logo" href="/" aria-label="Site Logo">
+        <a id="avlogo" class="gly-header-1-logo tx-logo" href="/" aria-label="Site Logo">
         <img src="wp-content/uploads/2024/03/logo-1.webp" alt="">
         <span class="shape-left"></span>
         </a>

--- a/HOODIE-WITH-LOGO--------------------.HTML
+++ b/HOODIE-WITH-LOGO--------------------.HTML
@@ -820,7 +820,7 @@ var woocommerce_params = {"ajax_url":"\/wp\/gilroy\/wp-admin\/admin-ajax.php","w
 <input type="hidden" name="_wpcf7_container_post" value="0" />
 <input type="hidden" name="_wpcf7_posted_data_hash" value="" />
 </div>
-<span class="wpcf7-form-control-wrap" data-name="email-592"><input size="40" class="wpcf7-form-control wpcf7-email wpcf7-validates-as-required wpcf7-text wpcf7-validates-as-email gly-form-1-input" aria-required="true" aria-invalid="false" placeholder="eamil address" value="" type="email" name="email-592" /></span><button class="gly-form-1-button" aria-label="submit" type="submit">subscribe</button><div class="wpcf7-response-output" aria-hidden="true"></div>
+<span class="wpcf7-form-control-wrap" data-name="email-592"><input size="40" class="wpcf7-form-control wpcf7-email wpcf7-validates-as-required wpcf7-text wpcf7-validates-as-email gly-form-1-input" aria-required="true" aria-invalid="false" placeholder="email address" value="" type="email" name="email-592" /></span><button class="gly-form-1-button" aria-label="submit" type="submit">subscribe</button><div class="wpcf7-response-output" aria-hidden="true"></div>
 </form>
 </div>
                             </div>


### PR DESCRIPTION
Added a margin left of 23 pixels to the site logo and rectified the spelling of email , email -> email.